### PR TITLE
fix: close claude call ledger file handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Close `claude_calls.jsonl` after each ledger write.**
+  `_maybe_write_ledger()` now uses a context manager for the per-call
+  ledger file, matching the existing rate-limit ledger path and
+  preventing leaked file descriptors in loop-heavy jobs.
 - **meta-scout: fix `--verbose` causing JSON array output.** Removed
   `--verbose` from `claude -p` invocation which caused `--output-format json`
   to return a message array instead of a result envelope, crashing on

--- a/src/claude_p/__init__.py
+++ b/src/claude_p/__init__.py
@@ -157,22 +157,23 @@ def _maybe_write_ledger(result: BackendResult) -> None:
         return
     run_dir = Path(job_dir) / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "claude_calls.jsonl").open("a").write(
-        json.dumps(
-            {
-                "cost_usd": result.cost_usd,
-                "input_tokens": result.input_tokens,
-                "output_tokens": result.output_tokens,
-                "cache_read_tokens": result.cache_read_tokens,
-                "cache_creation_tokens": result.cache_creation_tokens,
-                "num_turns": result.num_turns,
-                "session_id": result.session_id,
-                "is_error": result.is_error,
-                "model_usage": result.model_usage,
-            }
+    with (run_dir / "claude_calls.jsonl").open("a") as f:
+        f.write(
+            json.dumps(
+                {
+                    "cost_usd": result.cost_usd,
+                    "input_tokens": result.input_tokens,
+                    "output_tokens": result.output_tokens,
+                    "cache_read_tokens": result.cache_read_tokens,
+                    "cache_creation_tokens": result.cache_creation_tokens,
+                    "num_turns": result.num_turns,
+                    "session_id": result.session_id,
+                    "is_error": result.is_error,
+                    "model_usage": result.model_usage,
+                }
+            )
+            + "\n"
         )
-        + "\n"
-    )
     if result.rate_limit_events:
         with (run_dir / "claude_rate_limits.jsonl").open("a") as f:
             for ev in result.rate_limit_events:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+
+from claude_p import _maybe_write_ledger
+from claude_p.models import BackendResult
+
+
+class _TrackedFile:
+    def __init__(self, file_obj):
+        self._file_obj = file_obj
+
+    def write(self, data: str) -> int:
+        return self._file_obj.write(data)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._file_obj.close()
+
+    @property
+    def closed(self) -> bool:
+        return self._file_obj.closed
+
+    def __getattr__(self, name):
+        return getattr(self._file_obj, name)
+
+
+def test_maybe_write_ledger_closes_calls_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_P_RUN_ID", "run-123")
+    monkeypatch.setenv("CLAUDE_P_JOB_DIR", str(tmp_path))
+
+    tracked_path = tmp_path / "runs" / "run-123" / "claude_calls.jsonl"
+    original_open = Path.open
+    tracked = {}
+
+    def tracked_open(self, *args, **kwargs):
+        file_obj = original_open(self, *args, **kwargs)
+        if self == tracked_path:
+            wrapped = _TrackedFile(file_obj)
+            tracked["file"] = wrapped
+            return wrapped
+        return file_obj
+
+    monkeypatch.setattr(Path, "open", tracked_open)
+
+    _maybe_write_ledger(
+        BackendResult(
+            cost_usd=1.25,
+            input_tokens=10,
+            output_tokens=20,
+            cache_read_tokens=30,
+            cache_creation_tokens=40,
+            num_turns=2,
+            session_id="sess-1",
+            is_error=False,
+            model_usage={"claude-sonnet": {"costUSD": 1.25}},
+        )
+    )
+
+    assert tracked["file"].closed is True
+    ledger_entry = json.loads(tracked_path.read_text().strip())
+    assert ledger_entry["cost_usd"] == 1.25
+    assert ledger_entry["session_id"] == "sess-1"


### PR DESCRIPTION
## Summary
- wrap the `claude_calls.jsonl` ledger write in a context manager
- add a regression test that keeps the file object alive long enough to catch leaked descriptors
- update the changelog with the ledger-file fix

## Testing
- `pytest -q tests/test_init.py tests/test_ledger.py`
- `pytest -q`

Closes #5